### PR TITLE
More resilient gpg getting

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 	&& rm -r /var/lib/apt/lists/*
 
 # see https://httpd.apache.org/download.cgi#verify
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977
 
 ENV HTTPD_VERSION 2.2.29
 ENV HTTPD_BZ2_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 	&& rm -r /var/lib/apt/lists/*
 
 # see https://httpd.apache.org/download.cgi#verify
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8
 
 ENV HTTPD_VERSION 2.4.12
 ENV HTTPD_BZ2_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2


### PR DESCRIPTION
- move to "high-availability" [subset](https://sks-keyservers.net/overview-of-pools.php#pool_ha).

related: https://github.com/docker-library/php/pull/92