### PR TITLE
enable `most` mods on 2.2 (which is the default in 2.4)

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=' \
 	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
 	&& rm httpd.tar.bz2* \
 	&& cd src/httpd \
-	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX \
+	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd ../../ \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=' \
 	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
 	&& rm httpd.tar.bz2* \
 	&& cd src/httpd \
-	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX \
+	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd ../../ \


### PR DESCRIPTION
Fixes #6
Here are the mods we get, where previously the default of `2.2` was nothing: 
```console
$ docker run -it --rm new-httpd-2.2 ls modules/
httpd.exp		mod_authz_user.so  mod_include.so
mod_actions.so		mod_autoindex.so   mod_info.so
mod_alias.so		mod_cgi.so	   mod_log_config.so
mod_asis.so		mod_dav.so	   mod_logio.so
mod_auth_basic.so	mod_dav_fs.so	   mod_mime.so
mod_auth_digest.so	mod_dbd.so	   mod_negotiation.so
mod_authn_anon.so	mod_deflate.so	   mod_reqtimeout.so
mod_authn_dbd.so	mod_dir.so	   mod_rewrite.so
mod_authn_dbm.so	mod_dumpio.so	   mod_setenvif.so
mod_authn_default.so	mod_env.so	   mod_speling.so
mod_authn_file.so	mod_expires.so	   mod_ssl.so
mod_authz_dbm.so	mod_ext_filter.so  mod_status.so
mod_authz_default.so	mod_filter.so	   mod_substitute.so
mod_authz_groupfile.so	mod_headers.so	   mod_userdir.so
mod_authz_host.so	mod_ident.so	   mod_version.so
mod_authz_owner.so	mod_imagemap.so    mod_vhost_alias.so
```

There is no change to the modules included with `2.4`:

```console
$ docker run -it --rm new-httpd-2.4 ls modules/
httpd.exp		mod_dav_fs.so		    mod_proxy_fcgi.so
mod_access_compat.so	mod_dbd.so		    mod_proxy_ftp.so
mod_actions.so		mod_deflate.so		    mod_proxy_http.so
mod_alias.so		mod_dir.so		    mod_proxy_scgi.so
mod_allowmethods.so	mod_dumpio.so		    mod_proxy_wstunnel.so
mod_auth_basic.so	mod_env.so		    mod_ratelimit.so
mod_auth_digest.so	mod_expires.so		    mod_remoteip.so
mod_auth_form.so	mod_ext_filter.so	    mod_reqtimeout.so
mod_authn_anon.so	mod_file_cache.so	    mod_request.so
mod_authn_core.so	mod_filter.so		    mod_rewrite.so
mod_authn_dbd.so	mod_headers.so		    mod_sed.so
mod_authn_dbm.so	mod_include.so		    mod_session.so
mod_authn_file.so	mod_info.so		    mod_session_cookie.so
mod_authn_socache.so	mod_lbmethod_bybusyness.so  mod_session_crypto.so
mod_authnz_ldap.so	mod_lbmethod_byrequests.so  mod_session_dbd.so
mod_authz_core.so	mod_lbmethod_bytraffic.so   mod_setenvif.so
mod_authz_dbd.so	mod_lbmethod_heartbeat.so   mod_slotmem_shm.so
mod_authz_dbm.so	mod_ldap.so		    mod_socache_dbm.so
mod_authz_groupfile.so	mod_log_config.so	    mod_socache_memcache.so
mod_authz_host.so	mod_log_debug.so	    mod_socache_shmcb.so
mod_authz_owner.so	mod_logio.so		    mod_speling.so
mod_authz_user.so	mod_macro.so		    mod_ssl.so
mod_autoindex.so	mod_mime.so		    mod_status.so
mod_buffer.so		mod_negotiation.so	    mod_substitute.so
mod_cache.so		mod_proxy.so		    mod_unique_id.so
mod_cache_disk.so	mod_proxy_ajp.so	    mod_unixd.so
mod_cache_socache.so	mod_proxy_balancer.so	    mod_userdir.so
mod_cgid.so		mod_proxy_connect.so	    mod_version.so
mod_dav.so		mod_proxy_express.so	    mod_vhost_alias.so
```