### PR TITLE
Alpine httpd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ services: docker
 
 env:
   - VERSION=2.4
+  - VERSION=2.4 VARIANT=alpine
   - VERSION=2.2
 
 install:
@@ -10,8 +11,8 @@ install:
 
 before_script:
   - env | sort
-  - cd "$VERSION"
-  - image="httpd:$VERSION"
+  - cd "$VERSION/$VARIANT"
+  - image="httpd:${VERSION}${VARIANT:+-$VARIANT}"
 
 script:
   - docker build -t "$image" .

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.3
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN adduser -D www-data
+RUN addgroup -g 82 -S www-data \
+	&& adduser -u 82 -D -S -G www-data www-data
 
 ENV HTTPD_PREFIX /usr/local/apache2
 ENV PATH $PATH:$HTTPD_PREFIX/bin

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine:3.3
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN adduser -D www-data
+
+ENV HTTPD_PREFIX /usr/local/apache2
+ENV PATH $PATH:$HTTPD_PREFIX/bin
+RUN mkdir -p "$HTTPD_PREFIX" \
+	&& chown www-data:www-data "$HTTPD_PREFIX"
+WORKDIR $HTTPD_PREFIX
+
+# see https://httpd.apache.org/download.cgi#verify
+ENV GPG_KEY A93D62ECC3C8EA12DB220EC934EA76E6791485A8
+ENV HTTPD_VERSION 2.4.18
+ENV HTTPD_BZ2_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
+
+# see https://httpd.apache.org/docs/2.4/install.html#requirements
+RUN set -x \
+	&& apk add --no-cache --virtual .build-deps \
+		apr-dev \
+		apr-util-dev \
+		curl \
+		gcc \
+		gnupg \
+		libc-dev \
+		make \
+		openssl-dev \
+		pcre-dev \
+	&& curl -fSL "$HTTPD_BZ2_URL" -o httpd.tar.bz2 \
+	&& curl -fSL "$HTTPD_BZ2_URL.asc" -o httpd.tar.bz2.asc \
+# see https://httpd.apache.org/download.cgi#verify
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8 \
+	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
+	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
+	&& mkdir -p src \
+	&& tar -jxvf httpd.tar.bz2 -C src \
+	&& rm httpd.tar.bz2 \
+	&& cd src/httpd-$HTTPD_VERSION \
+	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
+	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
+	&& make install \
+	&& cd ../../ \
+	&& rm -r src/httpd-$HTTPD_VERSION \
+	&& sed -ri ' \
+		s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; \
+		s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g; \
+		' /usr/local/apache2/conf/httpd.conf \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)" \
+	&& apk add --virtual .httpd-rundeps $runDeps \
+		apr-dev \
+		apr-util-dev \
+	&& apk del .build-deps
+
+COPY httpd-foreground /usr/local/bin/
+
+EXPOSE 80
+CMD ["httpd-foreground"]

--- a/2.4/alpine/httpd-foreground
+++ b/2.4/alpine/httpd-foreground
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# Apache gets grumpy about PID files pre-existing
+rm -f /usr/local/apache2/logs/httpd.pid
+
+exec /usr/local/apache2/bin/httpd -DFOREGROUND


### PR DESCRIPTION
Some notes.
- use env for gpg key
- make sure runtime and build time deps are fetched only once
- be are that there is a busybox httpd too in the PATH (maybe we should delete it?)

diff from the debian based:

````diff
diff -ru 2.4/Dockerfile 2.4-alpine/Dockerfile
--- 2.4/Dockerfile	2016-01-15 16:06:00.709343409 +0100
+++ 2.4-alpine/Dockerfile	2016-01-17 21:10:16.108196165 +0100
@@ -1,7 +1,7 @@
-FROM debian:jessie
+FROM alpine:3.3
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-#RUN groupadd -r www-data && useradd -r --create-home -g www-data www-data
+RUN adduser -D www-data
 
 ENV HTTPD_PREFIX /usr/local/apache2
 ENV PATH $PATH:$HTTPD_PREFIX/bin
@@ -9,54 +9,51 @@
 	&& chown www-data:www-data "$HTTPD_PREFIX"
 WORKDIR $HTTPD_PREFIX
 
-# install httpd runtime dependencies
-# https://httpd.apache.org/docs/2.4/install.html#requirements
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		libapr1 \
-		libaprutil1 \
-		libapr1-dev \
-		libaprutil1-dev \
-		libpcre++0 \
-		libssl1.0.0 \
-	&& rm -r /var/lib/apt/lists/*
-
 # see https://httpd.apache.org/download.cgi#verify
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8
-
+ENV GPG_KEY A93D62ECC3C8EA12DB220EC934EA76E6791485A8
 ENV HTTPD_VERSION 2.4.18
 ENV HTTPD_BZ2_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 
-RUN buildDeps=' \
-		ca-certificates \
+# see https://httpd.apache.org/docs/2.4/install.html#requirements
+RUN set -x \
+	&& apk add --no-cache --virtual .build-deps \
+		apr-dev \
+		apr-util-dev \
 		curl \
-		bzip2 \
 		gcc \
-		libpcre++-dev \
-		libssl-dev \
+		gnupg \
+		libc-dev \
 		make \
-	' \
-	set -x \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
-	&& rm -r /var/lib/apt/lists/* \
+		openssl-dev \
+		pcre-dev \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
 	&& curl -SL "$HTTPD_BZ2_URL" -o httpd.tar.bz2 \
 	&& curl -SL "$HTTPD_BZ2_URL.asc" -o httpd.tar.bz2.asc \
 	&& gpg --verify httpd.tar.bz2.asc \
-	&& mkdir -p src/httpd \
-	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
+	&& mkdir -p src \
+	&& tar -jxvf httpd.tar.bz2 -C src \
 	&& rm httpd.tar.bz2* \
-	&& cd src/httpd \
+	&& cd src/httpd-$HTTPD_VERSION \
 	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
-	&& make -j"$(nproc)" \
+	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	&& cd ../../ \
-	&& rm -r src/httpd \
+	&& rm -r src/httpd-$HTTPD_VERSION \
 	&& sed -ri ' \
 		s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; \
 		s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g; \
 		' /usr/local/apache2/conf/httpd.conf \
-	&& apt-get purge -y --auto-remove $buildDeps
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)" \
+	&& apk add --virtual .httpd-rundeps $runDeps \
+		apr-dev \
+		apr-util-dev \
+	&& apk del .build-deps
 
 COPY httpd-foreground /usr/local/bin/
 
diff -ru 2.4/httpd-foreground 2.4-alpine/httpd-foreground
--- 2.4/httpd-foreground	2016-01-15 16:06:00.709343409 +0100
+++ 2.4-alpine/httpd-foreground	2016-01-17 21:19:14.989254819 +0100
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # Apache gets grumpy about PID files pre-existing
 rm -f /usr/local/apache2/logs/httpd.pid
 
-exec httpd -DFOREGROUND
+exec /usr/local/apache2/bin/httpd -DFOREGROUND
````