### PR TITLE
Build mod_proxy_*.so by default

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=' \
 	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
 	&& rm httpd.tar.bz2* \
 	&& cd src/httpd \
-	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
+	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most --enable-proxy \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd ../../ \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=' \
 	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
 	&& rm httpd.tar.bz2* \
 	&& cd src/httpd \
-	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
+	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most --enable-proxy \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd ../../ \


### PR DESCRIPTION
I think it would be useful if mod_proxy and friends were available by default.