### PR TITLE
Add libaprutil1-ldap closing issue 18 and adding support for mod_ldap

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libapr1 \
 		libaprutil1 \
+		libaprutil1-ldap \
 		libapr1-dev \
 		libaprutil1-dev \
 		libpcre++0 \


### PR DESCRIPTION
This PR updates the Dockerfile, adding libaprutil1-ldap in support of mod_ldap for Apache 2.4 LDAP integration.

Fixes #18