### PR TITLE
Build all the mods

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -49,7 +49,11 @@ RUN buildDeps=' \
 	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src/httpd \
-	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
+	&& ./configure \
+		--prefix=$HTTPD_PREFIX \
+# https://httpd.apache.org/docs/2.2/programs/configure.html
+# Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:
+		--enable-mods-shared='all ssl ldap cache proxy authn_alias mem_cache file_cache authnz_ldap charset_lite dav_lock disk_cache' \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd ../../ \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -38,6 +38,7 @@ RUN buildDeps=' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
+	\
 	&& curl -fSL "$HTTPD_BZ2_URL" -o httpd.tar.bz2 \
 	&& curl -fSL "$HTTPD_BZ2_URL.asc" -o httpd.tar.bz2.asc \
 # see https://httpd.apache.org/download.cgi#verify
@@ -45,23 +46,28 @@ RUN buildDeps=' \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977 \
 	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
 	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
-	&& mkdir -p src/httpd \
-	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
+	\
+	&& mkdir -p src \
+	&& tar -xvf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
-	&& cd src/httpd \
+	&& cd src \
+	\
 	&& ./configure \
-		--prefix=$HTTPD_PREFIX \
+		--prefix="$HTTPD_PREFIX" \
 # https://httpd.apache.org/docs/2.2/programs/configure.html
 # Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:
 		--enable-mods-shared='all ssl ldap cache proxy authn_alias mem_cache file_cache authnz_ldap charset_lite dav_lock disk_cache' \
 	&& make -j"$(nproc)" \
 	&& make install \
-	&& cd ../../ \
-	&& rm -r src/httpd \
-	&& sed -ri ' \
-		s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; \
-		s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g; \
-		' /usr/local/apache2/conf/httpd.conf \
+	\
+	&& cd .. \
+	&& rm -r src \
+	\
+	&& sed -ri \
+		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+		"$HTTPD_PREFIX/conf/httpd.conf" \
+	\
 	&& apt-get purge -y --auto-remove $buildDeps
 
 COPY httpd-foreground /usr/local/bin/

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -49,7 +49,9 @@ RUN buildDeps=' \
 	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src/httpd \
-	&& ./configure --enable-so --enable-ssl --prefix=$HTTPD_PREFIX --enable-mods-shared=most \
+	&& ./configure \
+		--prefix=$HTTPD_PREFIX \
+		--enable-mods-shared=reallyall \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& cd ../../ \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -38,6 +38,7 @@ RUN buildDeps=' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
+	\
 	&& curl -fSL "$HTTPD_BZ2_URL" -o httpd.tar.bz2 \
 	&& curl -fSL "$HTTPD_BZ2_URL.asc" -o httpd.tar.bz2.asc \
 # see https://httpd.apache.org/download.cgi#verify
@@ -45,21 +46,26 @@ RUN buildDeps=' \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8 \
 	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
 	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
-	&& mkdir -p src/httpd \
-	&& tar -xvf httpd.tar.bz2 -C src/httpd --strip-components=1 \
+	\
+	&& mkdir -p src \
+	&& tar -xvf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
-	&& cd src/httpd \
+	&& cd src \
+	\
 	&& ./configure \
-		--prefix=$HTTPD_PREFIX \
+		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
 	&& make -j"$(nproc)" \
 	&& make install \
-	&& cd ../../ \
-	&& rm -r src/httpd \
-	&& sed -ri ' \
-		s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g; \
-		s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g; \
-		' /usr/local/apache2/conf/httpd.conf \
+	\
+	&& cd .. \
+	&& rm -r src \
+	\
+	&& sed -ri \
+		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+		"$HTTPD_PREFIX/conf/httpd.conf" \
+	\
 	&& apt-get purge -y --auto-remove $buildDeps
 
 COPY httpd-foreground /usr/local/bin/


### PR DESCRIPTION
As pointed out by #13, `most` does not actually contain all the useful mods that are available in httpd.  I change my stance on compiling all the mods since they cannot be easily added later. 

The size change is negligible:
```console
REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
new-httpd           2.4                 78e26c9fafcc        About a minute ago   195 MB
new-httpd           2.2                 607dafaa1442        4 minutes ago        185.7 MB
httpd               2.4                 9e510755f4bc        4 days ago          194.5 MB
httpd               2.2                 03a2da88c612        4 days ago          185 MB
```

Here are all the mods that are not in the current version:
```console
$ comm -13 <(docker run --rm httpd:2.2 ls -1 modules/) <(docker run --rm new-httpd:2.2 ls -1 modules/)
mod_authn_alias.so
mod_authnz_ldap.so
mod_cache.so
mod_cern_meta.so
mod_charset_lite.so
mod_dav_lock.so
mod_disk_cache.so
mod_file_cache.so
mod_ldap.so
mod_log_forensic.so
mod_mem_cache.so
mod_mime_magic.so
mod_proxy.so
mod_proxy_ajp.so
mod_proxy_balancer.so
mod_proxy_connect.so
mod_proxy_ftp.so
mod_proxy_http.so
mod_proxy_scgi.so
mod_unique_id.so
mod_usertrack.so
$ comm -13 <(docker run --rm httpd:2.4 ls -1 modules/) <(docker run --rm new-httpd:2.4 ls -1 modules/)
mod_asis.so
mod_authnz_fcgi.so
mod_bucketeer.so
mod_case_filter.so
mod_case_filter_in.so
mod_cern_meta.so
mod_cgi.so
mod_cgid.so
mod_charset_lite.so
mod_data.so
mod_dav_lock.so
mod_dialup.so
mod_echo.so
mod_example_hooks.so
mod_example_ipc.so
mod_heartbeat.so
mod_heartmonitor.so
mod_ident.so
mod_imagemap.so
mod_isapi.so
mod_log_forensic.so
mod_mime_magic.so
mod_optional_fn_export.so
mod_optional_fn_import.so
mod_optional_hook_export.so
mod_optional_hook_import.so
mod_proxy_fdpass.so
mod_reflector.so
mod_slotmem_plain.so
mod_suexec.so
mod_usertrack.so
mod_watchdog.so

```
resolves #13