### PR TITLE
Add perl as a run dependency

### DIFF
--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN set -x \
 	&& runDeps=' \
 		apr-dev \
 		apr-util-dev \
+		perl \
 	' \
 	&& apk add --no-cache --virtual .build-deps \
 		$runDeps \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN set -x \
 	&& runDeps=' \
 		apr-dev \
 		apr-util-dev \
+		perl \
 	' \
 	&& apk add --no-cache --virtual .build-deps \
 		$runDeps \


### PR DESCRIPTION
Add perl as a run dependency so that apxs works. Fixes issue #27. Is
sort of related to #7.