### PR TITLE
Add support for mod_http2 mod_lua mod_proxy_html mod_xml2enc

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -9,6 +9,24 @@ RUN mkdir -p "$HTTPD_PREFIX" \
 	&& chown www-data:www-data "$HTTPD_PREFIX"
 WORKDIR $HTTPD_PREFIX
 
+# library for mod_http2
+ENV NGHTTP2_VERSION 1.16.0-1
+RUN { \
+		echo 'deb http://deb.debian.org/debian stretch main'; \
+	} > /etc/apt/sources.list.d/stretch.list \
+	&& { \
+# add a negative "Pin-Priority" so that we never ever get packages from stretch unless we explicitly request them
+		echo 'Package: *'; \
+		echo 'Pin: release n=stretch'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+# except nghttp2, which is the reason we're here
+		echo 'Package: libnghttp2*'; \
+		echo "Pin: version $NGHTTP2_VERSION"; \
+		echo 'Pin-Priority: 990'; \
+		echo; \
+	} > /etc/apt/preferences.d/unstable-nghttp2
+
 # install httpd runtime dependencies
 # https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN apt-get update \
@@ -18,8 +36,11 @@ RUN apt-get update \
 		libaprutil1-ldap \
 		libapr1-dev \
 		libaprutil1-dev \
+		liblua5.2-0 \
+		libnghttp2-14=$NGHTTP2_VERSION \
 		libpcre++0 \
 		libssl1.0.0 \
+		libxml2 \
 	&& rm -r /var/lib/apt/lists/*
 
 ENV HTTPD_VERSION 2.4.23
@@ -32,17 +53,23 @@ ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -x \
-	&& buildDeps=' \
+	# mod_http2 mod_lua mod_proxy_html mod_xml2enc
+	# https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/control?id=adb6f181257af28ee67af15fc49d2699a0080d4c
+	&& buildDeps=" \
 		bzip2 \
 		ca-certificates \
 		gcc \
+		libnghttp2-dev=$NGHTTP2_VERSION \
+		liblua5.2-dev \
 		libpcre++-dev \
 		libssl-dev \
+		libxml2-dev \
+		zlib1g-dev \
 		make \
 		wget \
-	' \
+	" \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& apt-get install -y --no-install-recommends -V $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
 	\
 	&& wget -O httpd.tar.bz2 "$HTTPD_BZ2_URL" \
@@ -55,7 +82,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
 	\
 	&& mkdir -p src \
-	&& tar -xvf httpd.tar.bz2 -C src --strip-components=1 \
+	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -36,11 +36,21 @@ RUN set -x \
 		gcc \
 		gnupg \
 		libc-dev \
+		# mod_proxy_html mod_xml2enc
+		libxml2-dev \
+		# mod_lua
+		lua-dev \
 		make \
+		# no mod_session_crypto: openssl-dev in alpine doesn't work, but libressl is edge only (and brings conflicts with edge packages)
 		openssl \
 		openssl-dev \
 		pcre-dev \
 		tar \
+		zlib-dev \
+	# https://bugs.alpinelinux.org/issues/6375
+	&& echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
+	# mod_http2
+	&& apk add --no-cache nghttp2-dev@edge \
 	\
 	&& wget -O httpd.tar.bz2 "$HTTPD_BZ2_URL" \
 	&& echo "$HTTPD_SHA1 *httpd.tar.bz2" | sha1sum -c - \
@@ -52,7 +62,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
 	\
 	&& mkdir -p src \
-	&& tar -xvf httpd.tar.bz2 -C src --strip-components=1 \
+	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
@@ -77,8 +87,11 @@ RUN set -x \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \
+	# `apk update` instead of --no-cache since `apk del` gets confused with `@edge` packages if there is no cache
+	&& apk update \
 	&& apk add --virtual .httpd-rundeps $runDeps \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	&& rm -rf /var/cache/apk/*
 
 COPY httpd-foreground /usr/local/bin/
 

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,7 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
+nghttp2VersionDebian="$(docker run -i --rm debian:stretch-slim bash -c 'apt-get update -qq && apt-cache show "$@"' -- "libnghttp2-dev" |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
 
 travisEnv=
 for version in "${versions[@]}"; do
@@ -19,6 +20,7 @@ for version in "${versions[@]}"; do
 		sed -ri \
 			-e 's/^(ENV HTTPD_VERSION) .*/\1 '"$fullVersion"'/' \
 			-e 's/^(ENV HTTPD_SHA1) .*/\1 '"$sha1"'/' \
+			-e 's/^(ENV NGHTTP2_VERSION) .*/\1 '"$nghttp2VersionDebian"'/' \
 			"$version/Dockerfile" "$version"/*/Dockerfile
 	)
 


### PR DESCRIPTION
Fixes #33.

`mod_http2` is only available in 2.4.17 and later. https://httpd.apache.org/docs/2.4/mod/mod_http2.html
