### PR TITLE
Copy 2.2-alpine compile args from 2.2, and remove useless dirs.

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -67,7 +67,7 @@ RUN set -x \
 	&& make install \
 	\
 	&& cd .. \
-	&& rm -r src \
+	&& rm -r src build man manual \
 	\
 	&& sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -57,12 +57,14 @@ RUN set -x \
 	\
 	&& ./configure \
 		--prefix="$HTTPD_PREFIX" \
-		--enable-mods-shared=reallyall \
+# https://httpd.apache.org/docs/2.2/programs/configure.html
+# Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:
+		--enable-mods-shared='all ssl ldap cache proxy authn_alias mem_cache file_cache authnz_ldap charset_lite dav_lock disk_cache' \
 	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\
 	&& cd .. \
-	&& rm -r src \
+	&& rm -r src build man manual \
 	\
 	&& sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \


### PR DESCRIPTION
Apache 2.2 does not support this compile arg `--enable-mods-shared=reallyall`. So I copy the right compile args from the tag `2.2`.

Then I remove the useless dirs `build, man, manual` for  reducing the image size:
Before: 92.06 MB
After: 80.92 MB