### PR TITLE
Fix http2 support on 2.4 in debian by using newer OpenSSL 1.0.2+

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:jessie-backports
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 #RUN groupadd -r www-data && useradd -r --create-home -g www-data www-data
@@ -11,6 +11,7 @@ WORKDIR $HTTPD_PREFIX
 
 # library for mod_http2
 ENV NGHTTP2_VERSION 1.17.0-1
+ENV OPENSSL_VERSION 1.0.2j-1~bpo8+1
 RUN { \
 		echo 'deb http://deb.debian.org/debian stretch main'; \
 	} > /etc/apt/sources.list.d/stretch.list \
@@ -39,7 +40,7 @@ RUN apt-get update \
 		liblua5.2-0 \
 		libnghttp2-14=$NGHTTP2_VERSION \
 		libpcre++0 \
-		libssl1.0.0 \
+		libssl1.0.0=$OPENSSL_VERSION \
 		libxml2 \
 	&& rm -r /var/lib/apt/lists/*
 
@@ -62,7 +63,7 @@ RUN set -x \
 		libnghttp2-dev=$NGHTTP2_VERSION \
 		liblua5.2-dev \
 		libpcre++-dev \
-		libssl-dev \
+		libssl-dev=$OPENSSL_VERSION \
 		libxml2-dev \
 		zlib1g-dev \
 		make \

--- a/update.sh
+++ b/update.sh
@@ -10,6 +10,7 @@ fi
 versions=( "${versions[@]%/}" )
 
 nghttp2VersionDebian="$(docker run -i --rm debian:stretch-slim bash -c 'apt-get update -qq && apt-cache show "$@"' -- "libnghttp2-dev" |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
+opensslVersionDebian="$(docker run -i --rm debian:jessie-backports bash -c 'apt-get update -qq && apt-cache show "$@"' -- "openssl" |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
 
 travisEnv=
 for version in "${versions[@]}"; do
@@ -21,6 +22,7 @@ for version in "${versions[@]}"; do
 			-e 's/^(ENV HTTPD_VERSION) .*/\1 '"$fullVersion"'/' \
 			-e 's/^(ENV HTTPD_SHA1) .*/\1 '"$sha1"'/' \
 			-e 's/^(ENV NGHTTP2_VERSION) .*/\1 '"$nghttp2VersionDebian"'/' \
+			-e 's/^(ENV OPENSSL_VERSION) .*/\1 '"$opensslVersionDebian"'/' \
 			"$version/Dockerfile" "$version"/*/Dockerfile
 	)
 


### PR DESCRIPTION
Fixes #42.

```console
$ curl -v --http2 https://server-with-h2-and-ssl
...
* ALPN, offering h2
* ALPN, offering http/1.1
* SSL connection using TLS1.2 / ECDHE_RSA_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
```