### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x \
 	&& buildDeps=' \
 		bzip2 \
 		ca-certificates \
+		dpkg-dev \
 		gcc \
 		libpcre++-dev \
 		libssl-dev \
@@ -55,11 +56,13 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
 	\
 	&& mkdir -p src \
-	&& tar -xvf httpd.tar.bz2 -C src --strip-components=1 \
+	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 # https://httpd.apache.org/docs/2.2/programs/configure.html
 # Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -37,6 +37,8 @@ RUN set -x \
 	&& apk add --no-cache --virtual .build-deps \
 		$runDeps \
 		ca-certificates \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gnupg \
 		libc-dev \
@@ -56,16 +58,18 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" httpd.tar.bz2.asc \
 	\
 	&& mkdir -p src \
-	&& tar -xvf httpd.tar.bz2 -C src --strip-components=1 \
+	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 # https://httpd.apache.org/docs/2.2/programs/configure.html
 # Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:
 		--enable-mods-shared='all ssl ldap cache proxy authn_alias mem_cache file_cache authnz_ldap charset_lite dav_lock disk_cache' \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& cd .. \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -59,9 +59,10 @@ RUN set -x \
 	&& buildDeps=" \
 		bzip2 \
 		ca-certificates \
+		dpkg-dev \
 		gcc \
-		libnghttp2-dev=$NGHTTP2_VERSION \
 		liblua5.2-dev \
+		libnghttp2-dev=$NGHTTP2_VERSION \
 		libpcre++-dev \
 		libssl-dev=$OPENSSL_VERSION \
 		libxml2-dev \
@@ -87,7 +88,9 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
 	&& make -j "$(nproc)" \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -33,6 +33,8 @@ RUN set -x \
 	&& apk add --no-cache --virtual .build-deps \
 		$runDeps \
 		ca-certificates \
+		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gnupg \
 		libc-dev \
@@ -65,10 +67,12 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& cd .. \


### PR DESCRIPTION
This is along the same lines as:

- https://github.com/jessfraz/irssi/pull/14
- https://github.com/docker-library/php/pull/429
- https://github.com/docker-library/postgres/pull/284
- https://github.com/docker-library/python/pull/198
- https://github.com/docker-library/ruby/pull/127
- https://github.com/docker-library/tomcat/pull/70
- https://github.com/docker-library/memcached/pull/13
- https://github.com/tianon/docker-bash/pull/3