### PR TITLE
Bump 2.4 to use alpine 3.6

### DIFF
--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 # ensure www-data user exists
 RUN set -x \


### PR DESCRIPTION
Fixes #50 (2.2 cannot be updated, see comment in [the Dockerfile](https://github.com/docker-library/httpd/blob/6e4544875f3f12052f8b5fd4990150cc48a59379/2.2/alpine/Dockerfile#L1-L4)).