### PR TITLE
Update to 2.4.27 (alpine)

### DIFF
--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -78,6 +78,12 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+# https://bz.apache.org/bugzilla/show_bug.cgi?id=61184
+# https://github.com/docker-library/httpd/pull/68
+	&& wget -O libressl.patch 'https://git.alpinelinux.org/cgit/aports/plain/main/apache2/libressl.patch?id=d7292029f25a131a0f15ebc3bc2300e75f4c131a' \
+	&& patch -p1 < libressl.patch \
+	&& rm libressl.patch \
+	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -15,8 +15,8 @@ RUN mkdir -p "$HTTPD_PREFIX" \
 	&& chown www-data:www-data "$HTTPD_PREFIX"
 WORKDIR $HTTPD_PREFIX
 
-ENV HTTPD_VERSION 2.4.25
-ENV HTTPD_SHA1 bd6d138c31c109297da2346c6e7b93b9283993d2
+ENV HTTPD_VERSION 2.4.27
+ENV HTTPD_SHA1 699e4e917e8fb5fd7d0ce7e009f8256ed02ec6fc
 
 # https://issues.apache.org/jira/browse/INFRA-8753?focusedCommentId=14735394#comment-14735394
 ENV HTTPD_BZ2_URL https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-$HTTPD_VERSION.tar.bz2


### PR DESCRIPTION
See https://github.com/docker-library/httpd/pull/57 for the previous discussion about this bump and https://bz.apache.org/bugzilla/show_bug.cgi?id=61184 for upstream's discussion of it (where they're also discussing an official patch for the libressl vs openssl issue we're seeing).