### PR TITLE
Build httpd with HTTP/2 support

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -103,6 +103,7 @@ RUN set -x \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
+		--enable-http2 \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -89,6 +89,7 @@ RUN set -x \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
+		--enable-http2 \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\


### PR DESCRIPTION
Every depencies to support HTTP/2 are installed but httpd is not built with http2 support.

Here I use the flag `--enable-http2` as shown by [the official documentation](https://httpd.apache.org/docs/2.4/en/howto/http2.html#building).

Then use `Protocols h2 http/1.1` to enable it by vhost.