### PR TITLE
changed locale to enable UTF-8 support

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -116,6 +116,8 @@ RUN set -x \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps
 
+ENV LANG C.UTF-8
+
 COPY httpd-foreground /usr/local/bin/
 
 EXPOSE 80


### PR DESCRIPTION
Currently the locale defaults to `POSIX` which means that only ASCII characters are supported in the Docker container. Changed locale enviroment variable `LANG` to enable UTF-8 support.