### PR TITLE
Adjust scanelf to properly detect runDeps

### DIFF
--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -92,11 +92,10 @@ RUN set -x \
 		"$HTTPD_PREFIX/conf/httpd.conf" \
 	\
 	&& runDeps="$runDeps $( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .httpd-rundeps $runDeps \
 	&& apk del .build-deps

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -101,11 +101,10 @@ RUN set -x \
 		"$HTTPD_PREFIX/conf/httpd.conf" \
 	\
 	&& runDeps="$runDeps $( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .httpd-rundeps $runDeps \
 	&& apk del .build-deps


### PR DESCRIPTION
Copying the improvement from https://github.com/docker-library/ruby/pull/161.  Should be no discernible change in packages installed, but does make the sub-shell a little easier to understand.