### PR TITLE
Add support for applying patches.

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -34,6 +34,9 @@ ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
 
+# Patches to apply
+COPY PATCHES $HTTPD_PREFIX
+
 # see https://httpd.apache.org/docs/2.2/install.html#requirements
 RUN set -x \
 	&& buildDeps=' \
@@ -69,6 +72,20 @@ RUN set -x \
 	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
+	\
+	&& { \
+	     grep -Ev '^(#|\s*$)' ${HTTPD_PREFIX}/PATCHES | while read -r PATCH; do \
+	     	   PATCH_FL=${PATCH%% *}; \
+		   PATCH_URL=${PATCH##* }; \
+		   PATCH_TMP=${PATCH% *}; \
+		   PATCH_SUM=${PATCH_TMP##* }; \
+		   wget -O ${PATCH_FL} "${PATCH_URL}" \
+		   	&& echo "${PATCH_SUM} ${PATCH_FL}" | sha256sum -c - \
+			&& patch -p0 < ${PATCH_FL} \
+			&& rm ${PATCH_FL} || break 0; \
+	     done \
+	 ; } \
+	&& rm $HTTPD_PREFIX/PATCHES \
 	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \

--- a/2.2/PATCHES
+++ b/2.2/PATCHES
@@ -1,0 +1,5 @@
+# Patches to download and apply to current version source tree
+# Blank lines, lines containing only whitespace and comments will be ignored.
+# Format: filename sha256sum url
+#
+CVE-2017-9798-patch-2.2.patch 42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46 https://www.apache.org/dist/httpd/patches/apply_to_2.2.34/CVE-2017-9798-patch-2.2.patch

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -31,6 +31,9 @@ ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
 
+# Patches to apply
+COPY PATCHES $HTTPD_PREFIX
+
 # see https://httpd.apache.org/docs/2.2/install.html#requirements
 RUN set -x \
 	&& runDeps=' \
@@ -72,6 +75,20 @@ RUN set -x \
 	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
+	\
+	&& { \
+	     grep -Ev '^(#|\s*$)' ${HTTPD_PREFIX}/PATCHES | while read -r PATCH; do \
+	     	   PATCH_FL=${PATCH%% *}; \
+		   PATCH_URL=${PATCH##* }; \
+		   PATCH_TMP=${PATCH% *}; \
+		   PATCH_SUM=${PATCH_TMP##* }; \
+		   wget -O ${PATCH_FL} "${PATCH_URL}" \
+		   	&& echo "${PATCH_SUM} ${PATCH_FL}" | sha256sum -c - \
+			&& patch -p0 < ${PATCH_FL} \
+			&& rm ${PATCH_FL} || break 0; \
+	     done \
+	 ; } \
+	&& rm $HTTPD_PREFIX/PATCHES \
 	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \

--- a/2.2/alpine/PATCHES
+++ b/2.2/alpine/PATCHES
@@ -1,0 +1,5 @@
+# Patches to download and apply to current version source tree
+# Blank lines, lines containing only whitespace and comments will be ignored.
+# Format: filename sha256sum url
+#
+CVE-2017-9798-patch-2.2.patch 42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46 https://www.apache.org/dist/httpd/patches/apply_to_2.2.34/CVE-2017-9798-patch-2.2.patch

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -56,6 +56,9 @@ ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
 
+# Patches to apply
+COPY PATCHES $HTTPD_PREFIX
+
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -x \
 	# mod_http2 mod_lua mod_proxy_html mod_xml2enc
@@ -97,6 +100,20 @@ RUN set -x \
 	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
+	\
+	&& { \
+	     grep -Ev '^(#|\s*$)' ${HTTPD_PREFIX}/PATCHES | while read -r PATCH; do \
+	     	   PATCH_FL=${PATCH%% *}; \
+		   PATCH_URL=${PATCH##* }; \
+		   PATCH_TMP=${PATCH% *}; \
+		   PATCH_SUM=${PATCH_TMP##* }; \
+		   wget -O ${PATCH_FL} "${PATCH_URL}" \
+		   	&& echo "${PATCH_SUM} ${PATCH_FL}" | sha256sum -c - \
+			&& patch -p0 < ${PATCH_FL} \
+			&& rm ${PATCH_FL} || break 0; \
+	     done \
+	 ; } \
+	&& rm $HTTPD_PREFIX/PATCHES \
 	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \

--- a/2.4/PATCHES
+++ b/2.4/PATCHES
@@ -1,0 +1,6 @@
+# Patches to download and apply to current version source tree
+# Blank lines, lines containing only whitespace and comments will be ignored.
+# Format: filename sha256sum url
+#
+PR61382-Fix.patch 12c0926dad2c5421e9f7eb7b9dc1b5b41a8ceeb3a72d90a58bfca23aae2b132d https://www.apache.org/dist/httpd/patches/apply_to_2.4.27/PR61382-Fix.patch
+CVE-2017-9798-patch-2.4.patch eb2309b15eaf35deaa87f815fa5fb88e46b259991edd960e64000a98a7fb2f25 https://www.apache.org/dist/httpd/patches/apply_to_2.4.27/CVE-2017-9798-patch-2.4.patch

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -27,6 +27,9 @@ ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
 ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
 
+# Patches to apply
+COPY PATCHES $HTTPD_PREFIX
+
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -x \
 	&& runDeps=' \
@@ -83,6 +86,20 @@ RUN set -x \
 	&& wget -O libressl.patch 'https://git.alpinelinux.org/cgit/aports/plain/main/apache2/libressl.patch?id=d7292029f25a131a0f15ebc3bc2300e75f4c131a' \
 	&& patch -p1 < libressl.patch \
 	&& rm libressl.patch \
+	\
+	&& { \
+	     grep -Ev '^(#|\s*$)' ${HTTPD_PREFIX}/PATCHES | while read -r PATCH; do \
+	     	   PATCH_FL=${PATCH%% *}; \
+		   PATCH_URL=${PATCH##* }; \
+		   PATCH_TMP=${PATCH% *}; \
+		   PATCH_SUM=${PATCH_TMP##* }; \
+		   wget -O ${PATCH_FL} "${PATCH_URL}" \
+		   	&& echo "${PATCH_SUM} ${PATCH_FL}" | sha256sum -c - \
+			&& patch -p0 < ${PATCH_FL} \
+			&& rm ${PATCH_FL} || break 0; \
+	     done \
+	 ; } \
+	 && rm $HTTPD_PREFIX/PATCHES \
 	\
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \

--- a/2.4/alpine/PATCHES
+++ b/2.4/alpine/PATCHES
@@ -1,0 +1,6 @@
+# Patches to download and apply to current version source tree
+# Blank lines, lines containing only whitespace and comments will be ignored.
+# Format: filename sha256sum url
+#
+PR61382-Fix.patch 12c0926dad2c5421e9f7eb7b9dc1b5b41a8ceeb3a72d90a58bfca23aae2b132d https://www.apache.org/dist/httpd/patches/apply_to_2.4.27/PR61382-Fix.patch
+CVE-2017-9798-patch-2.4.patch eb2309b15eaf35deaa87f815fa5fb88e46b259991edd960e64000a98a7fb2f25 https://www.apache.org/dist/httpd/patches/apply_to_2.4.27/CVE-2017-9798-patch-2.4.patch


### PR DESCRIPTION
This is another potential solution for #75, applying patches from upstream to source before building.  Patches need to be downloaded from http://www.apache.org/dist/httpd/patches/, tested/validated, then their filenames/checksums/urls added to the per-version, per-Linux-base PATCHES file.

During the build, lines will be read from the PATCHES file and patches downloaded/verified and applied in the order they appear in the file.  I did not see any GPG signing from the upstream project for these patches, so this relies on checking the sha256sum.

When changing the upstream http server release, these PATCHES files will need to be edited to remove all non-applicable patch entries.

Note that we're using bash parameter expansion to parse lines from the PATCHES file.  Could also be accomplished by other means (awk?) if necessary.
