### PR TITLE
Add support for applying patches.

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -70,6 +70,14 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+# Apply source patches
+        && { \
+             wget -O CVE-2017-9798-patch-2.2.patch "https://www-us.apache.org/dist/httpd/patches/apply_to_2.2.34/CVE-2017-9798-patch-2.2.patch" \
+               && echo "42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46 CVE-2017-9798-patch-2.2.patch" | sha256sum -c - \
+               && patch -p0 < CVE-2017-9798-patch-2.2.patch \
+               && rm CVE-2017-9798-patch-2.2.patch \
+        ; } \
+# End source patch list
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p "$HTTPD_PREFIX" \
 WORKDIR $HTTPD_PREFIX
 
 # install httpd runtime dependencies
-# https://httpd.apache.org/docs/2.4/install.html#requirements
+# https://httpd.apache.org/docs/2.2/install.html#requirements
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libapr1 \
@@ -23,20 +23,23 @@ RUN apt-get update \
 	&& rm -r /var/lib/apt/lists/*
 
 ENV HTTPD_VERSION 2.2.34
-ENV HTTPD_SHA1 829206394e238af0b800fc78d19c74ee466ecb23
+ENV HTTPD_SHA256 e53183d5dfac5740d768b4c9bea193b1099f4b06b57e5f28d7caaf9ea7498160
 
+# https://httpd.apache.org/security/vulnerabilities_22.html
+ENV HTTPD_PATCHES="CVE-2017-9798-patch-2.2.patch 42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46"
+
+ENV APACHE_DIST_URLS \
 # https://issues.apache.org/jira/browse/INFRA-8753?focusedCommentId=14735394#comment-14735394
-ENV HTTPD_BZ2_URL https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-$HTTPD_VERSION.tar.bz2
-# not all the mirrors actually carry the .asc files :'(
-ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
-
-# if the version is outdated, we have to pull from the archive :/
-ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
-ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
+	https://www.apache.org/dyn/closer.cgi?action=download&filename= \
+# if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
+	https://www-us.apache.org/dist/ \
+	https://www.apache.org/dist/ \
+	https://archive.apache.org/dist/
 
 # see https://httpd.apache.org/docs/2.2/install.html#requirements
-RUN set -x \
-	&& buildDeps=' \
+RUN set -eux; \
+	\
+	buildDeps=' \
 		bzip2 \
 		ca-certificates \
 		dpkg-dev \
@@ -45,58 +48,72 @@ RUN set -x \
 		libssl-dev \
 		make \
 		wget \
-	' \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
-	&& rm -r /var/lib/apt/lists/* \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends -V $buildDeps; \
+	rm -r /var/lib/apt/lists/*; \
 	\
-	&& { \
-		wget -O httpd.tar.bz2 "$HTTPD_BZ2_URL" \
-		|| wget -O httpd.tar.bz2 "$HTTPD_BZ2_FALLBACK_URL" \
-	; } \
-	&& echo "$HTTPD_SHA1 *httpd.tar.bz2" | sha1sum -c - \
+	ddist() { \
+		local f="$1"; shift; \
+		local distFile="$1"; shift; \
+		local success=; \
+		local distUrl=; \
+		for distUrl in $APACHE_DIST_URLS; do \
+			if wget -O "$f" "$distUrl$distFile"; then \
+				success=1; \
+				break; \
+			fi; \
+		done; \
+		[ -n "$success" ]; \
+	}; \
+	\
+	ddist 'httpd.tar.bz2' "httpd/httpd-$HTTPD_VERSION.tar.bz2"; \
+	echo "$HTTPD_SHA256 *httpd.tar.bz2" | sha256sum -c -; \
+	\
 # see https://httpd.apache.org/download.cgi#verify
-	&& { \
-		wget -O httpd.tar.bz2.asc "$HTTPD_ASC_URL" \
-		|| wget -O httpd.tar.bz2.asc "$HTTPD_ASC_FALLBACK_URL" \
-	; } \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977 \
-	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
-	&& rm -rf "$GNUPGHOME" httpd.tar.bz2.asc \
+	ddist 'httpd.tar.bz2.asc' "httpd/httpd-$HTTPD_VERSION.tar.bz2.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977; \
+	gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2; \
+	rm -rf "$GNUPGHOME" httpd.tar.bz2.asc; \
 	\
-	&& mkdir -p src \
-	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
-	&& rm httpd.tar.bz2 \
-	&& cd src \
+	mkdir -p src; \
+	tar -xf httpd.tar.bz2 -C src --strip-components=1; \
+	rm httpd.tar.bz2; \
+	cd src; \
 	\
-# Apply source patches
-        && { \
-             wget -O CVE-2017-9798-patch-2.2.patch "https://www-us.apache.org/dist/httpd/patches/apply_to_2.2.34/CVE-2017-9798-patch-2.2.patch" \
-               && echo "42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46 CVE-2017-9798-patch-2.2.patch" | sha256sum -c - \
-               && patch -p0 < CVE-2017-9798-patch-2.2.patch \
-               && rm CVE-2017-9798-patch-2.2.patch \
-        ; } \
-# End source patch list
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
+	patches() { \
+		while [ "$#" -gt 0 ]; do \
+			local patchFile="$1"; shift; \
+			local patchSha256="$1"; shift; \
+			ddist "$patchFile" "httpd/patches/apply_to_$HTTPD_VERSION/$patchFile"; \
+			echo "$patchSha256 *$patchFile" | sha256sum -c -; \
+			patch -p0 < "$patchFile"; \
+			rm -f "$patchFile"; \
+		done; \
+	}; \
+	patches $HTTPD_PATCHES; \
+	\
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	./configure \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 # https://httpd.apache.org/docs/2.2/programs/configure.html
 # Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:
 		--enable-mods-shared='all ssl ldap cache proxy authn_alias mem_cache file_cache authnz_ldap charset_lite dav_lock disk_cache' \
-	&& make -j "$(nproc)" \
-	&& make install \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
 	\
-	&& cd .. \
-	&& rm -r src man manual \
+	cd ..; \
+	rm -r src man manual; \
 	\
-	&& sed -ri \
+	sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-		"$HTTPD_PREFIX/conf/httpd.conf" \
+		"$HTTPD_PREFIX/conf/httpd.conf"; \
 	\
-	&& apt-get purge -y --auto-remove $buildDeps
+	apt-get purge -y --auto-remove $buildDeps
 
 COPY httpd-foreground /usr/local/bin/
 

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -20,26 +20,29 @@ RUN mkdir -p "$HTTPD_PREFIX" \
 WORKDIR $HTTPD_PREFIX
 
 ENV HTTPD_VERSION 2.2.34
-ENV HTTPD_SHA1 829206394e238af0b800fc78d19c74ee466ecb23
+ENV HTTPD_SHA256 e53183d5dfac5740d768b4c9bea193b1099f4b06b57e5f28d7caaf9ea7498160
 
+# https://httpd.apache.org/security/vulnerabilities_22.html
+ENV HTTPD_PATCHES="CVE-2017-9798-patch-2.2.patch 42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46"
+
+ENV APACHE_DIST_URLS \
 # https://issues.apache.org/jira/browse/INFRA-8753?focusedCommentId=14735394#comment-14735394
-ENV HTTPD_BZ2_URL https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-$HTTPD_VERSION.tar.bz2
-# not all the mirrors actually carry the .asc files :'(
-ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
-
-# if the version is outdated, we have to pull from the archive :/
-ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
-ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
+	https://www.apache.org/dyn/closer.cgi?action=download&filename= \
+# if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
+	https://www-us.apache.org/dist/ \
+	https://www.apache.org/dist/ \
+	https://archive.apache.org/dist/
 
 # see https://httpd.apache.org/docs/2.2/install.html#requirements
-RUN set -x \
-	&& runDeps=' \
+RUN set -eux; \
+	\
+	runDeps=' \
 		apr-dev \
 		apr-util-dev \
 		apr-util-ldap \
 		perl \
-	' \
-	&& apk add --no-cache --virtual .build-deps \
+	'; \
+	apk add --no-cache --virtual .build-deps \
 		$runDeps \
 		ca-certificates \
 		coreutils \
@@ -52,61 +55,78 @@ RUN set -x \
 		openssl-dev \
 		pcre-dev \
 		tar \
+# install GNU wget (Busybox wget in Alpine 3.4 gives us "wget: error getting response: Connection reset by peer" for some reason)
+		wget \
+	; \
 	\
-	&& { \
-		wget -O httpd.tar.bz2 "$HTTPD_BZ2_URL" \
-		|| wget -O httpd.tar.bz2 "$HTTPD_BZ2_FALLBACK_URL" \
-	; } \
-	&& echo "$HTTPD_SHA1 *httpd.tar.bz2" | sha1sum -c - \
+	ddist() { \
+		local f="$1"; shift; \
+		local distFile="$1"; shift; \
+		local success=; \
+		local distUrl=; \
+		for distUrl in $APACHE_DIST_URLS; do \
+			if wget -O "$f" "$distUrl$distFile"; then \
+				success=1; \
+				break; \
+			fi; \
+		done; \
+		[ -n "$success" ]; \
+	}; \
+	\
+	ddist 'httpd.tar.bz2' "httpd/httpd-$HTTPD_VERSION.tar.bz2"; \
+	echo "$HTTPD_SHA256 *httpd.tar.bz2" | sha256sum -c -; \
+	\
 # see https://httpd.apache.org/download.cgi#verify
-	&& { \
-		wget -O httpd.tar.bz2.asc "$HTTPD_ASC_URL" \
-		|| wget -O httpd.tar.bz2.asc "$HTTPD_ASC_FALLBACK_URL" \
-	; } \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977 \
-	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
-	&& rm -rf "$GNUPGHOME" httpd.tar.bz2.asc \
+	ddist 'httpd.tar.bz2.asc' "httpd/httpd-$HTTPD_VERSION.tar.bz2.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B1B96F45DFBDCCF974019235193F180AB55D9977; \
+	gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2; \
+	rm -rf "$GNUPGHOME" httpd.tar.bz2.asc; \
 	\
-	&& mkdir -p src \
-	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
-	&& rm httpd.tar.bz2 \
-	&& cd src \
+	mkdir -p src; \
+	tar -xf httpd.tar.bz2 -C src --strip-components=1; \
+	rm httpd.tar.bz2; \
+	cd src; \
 	\
-# Apply source patches
-        && { \
-             wget -O CVE-2017-9798-patch-2.2.patch "https://www-us.apache.org/dist/httpd/patches/apply_to_2.2.34/CVE-2017-9798-patch-2.2.patch" \
-               && echo "42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46 CVE-2017-9798-patch-2.2.patch" | sha256sum -c - \
-               && patch -p0 < CVE-2017-9798-patch-2.2.patch \
-               && rm CVE-2017-9798-patch-2.2.patch \
-        ; } \
-# End source patch list
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
+	patches() { \
+		while [ "$#" -gt 0 ]; do \
+			local patchFile="$1"; shift; \
+			local patchSha256="$1"; shift; \
+			ddist "$patchFile" "httpd/patches/apply_to_$HTTPD_VERSION/$patchFile"; \
+			echo "$patchSha256 *$patchFile" | sha256sum -c -; \
+			patch -p0 < "$patchFile"; \
+			rm -f "$patchFile"; \
+		done; \
+	}; \
+	patches $HTTPD_PATCHES; \
+	\
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	./configure \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 # https://httpd.apache.org/docs/2.2/programs/configure.html
 # Caveat: --enable-mods-shared=all does not actually build all modules. To build all modules then, one might use:
 		--enable-mods-shared='all ssl ldap cache proxy authn_alias mem_cache file_cache authnz_ldap charset_lite dav_lock disk_cache' \
-	&& make -j "$(nproc)" \
-	&& make install \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
 	\
-	&& cd .. \
-	&& rm -r src man manual \
+	cd ..; \
+	rm -r src man manual; \
 	\
-	&& sed -ri \
+	sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-		"$HTTPD_PREFIX/conf/httpd.conf" \
+		"$HTTPD_PREFIX/conf/httpd.conf"; \
 	\
-	&& runDeps="$runDeps $( \
+	runDeps="$runDeps $( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)" \
-	&& apk add --virtual .httpd-rundeps $runDeps \
-	&& apk del .build-deps
+	)"; \
+	apk add --virtual .httpd-rundeps $runDeps; \
+	apk del .build-deps
 
 COPY httpd-foreground /usr/local/bin/
 

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -73,6 +73,14 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+# Apply source patches
+        && { \
+             wget -O CVE-2017-9798-patch-2.2.patch "https://www-us.apache.org/dist/httpd/patches/apply_to_2.2.34/CVE-2017-9798-patch-2.2.patch" \
+               && echo "42c610f8a8f8d4d08664db6d9857120c2c252c9b388d56f238718854e6013e46 CVE-2017-9798-patch-2.2.patch" | sha256sum -c - \
+               && patch -p0 < CVE-2017-9798-patch-2.2.patch \
+               && rm CVE-2017-9798-patch-2.2.patch \
+        ; } \
+# End source patch list
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -98,6 +98,8 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+# Apply source patches
+# End source patch list
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -45,22 +45,25 @@ RUN apt-get update \
 	&& rm -r /var/lib/apt/lists/*
 
 ENV HTTPD_VERSION 2.4.28
-ENV HTTPD_SHA1 0b37522b808dcee72e1d56d656b0def530b820a2
+ENV HTTPD_SHA256 c1197a3a62a4ab5c584ab89b249af38cf28b4adee9c0106b62999fd29f920666
 
+# https://httpd.apache.org/security/vulnerabilities_24.html
+ENV HTTPD_PATCHES=""
+
+ENV APACHE_DIST_URLS \
 # https://issues.apache.org/jira/browse/INFRA-8753?focusedCommentId=14735394#comment-14735394
-ENV HTTPD_BZ2_URL https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-$HTTPD_VERSION.tar.bz2
-# not all the mirrors actually carry the .asc files :'(
-ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
-
-# if the version is outdated, we have to pull from the archive :/
-ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
-ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
+	https://www.apache.org/dyn/closer.cgi?action=download&filename= \
+# if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
+	https://www-us.apache.org/dist/ \
+	https://www.apache.org/dist/ \
+	https://archive.apache.org/dist/
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
-RUN set -x \
+RUN set -eux; \
+	\
 	# mod_http2 mod_lua mod_proxy_html mod_xml2enc
 	# https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/control?id=adb6f181257af28ee67af15fc49d2699a0080d4c
-	&& buildDeps=" \
+	buildDeps=" \
 		bzip2 \
 		ca-certificates \
 		dpkg-dev \
@@ -73,50 +76,70 @@ RUN set -x \
 		zlib1g-dev \
 		make \
 		wget \
-	" \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends -V $buildDeps \
-	&& rm -r /var/lib/apt/lists/* \
+	"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends -V $buildDeps; \
+	rm -r /var/lib/apt/lists/*; \
 	\
-	&& { \
-		wget -O httpd.tar.bz2 "$HTTPD_BZ2_URL" \
-		|| wget -O httpd.tar.bz2 "$HTTPD_BZ2_FALLBACK_URL" \
-	; } \
-	&& echo "$HTTPD_SHA1 *httpd.tar.bz2" | sha1sum -c - \
+	ddist() { \
+		local f="$1"; shift; \
+		local distFile="$1"; shift; \
+		local success=; \
+		local distUrl=; \
+		for distUrl in $APACHE_DIST_URLS; do \
+			if wget -O "$f" "$distUrl$distFile"; then \
+				success=1; \
+				break; \
+			fi; \
+		done; \
+		[ -n "$success" ]; \
+	}; \
+	\
+	ddist 'httpd.tar.bz2' "httpd/httpd-$HTTPD_VERSION.tar.bz2"; \
+	echo "$HTTPD_SHA256 *httpd.tar.bz2" | sha256sum -c -; \
+	\
 # see https://httpd.apache.org/download.cgi#verify
-	&& { \
-		wget -O httpd.tar.bz2.asc "$HTTPD_ASC_URL" \
-		|| wget -O httpd.tar.bz2.asc "$HTTPD_ASC_FALLBACK_URL" \
-	; } \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8 \
-	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
-	&& rm -rf "$GNUPGHOME" httpd.tar.bz2.asc \
+	ddist 'httpd.tar.bz2.asc' "httpd/httpd-$HTTPD_VERSION.tar.bz2.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8; \
+	gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2; \
+	rm -rf "$GNUPGHOME" httpd.tar.bz2.asc; \
 	\
-	&& mkdir -p src \
-	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
-	&& rm httpd.tar.bz2 \
-	&& cd src \
+	mkdir -p src; \
+	tar -xf httpd.tar.bz2 -C src --strip-components=1; \
+	rm httpd.tar.bz2; \
+	cd src; \
 	\
-# Apply source patches
-# End source patch list
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
+	patches() { \
+		while [ "$#" -gt 0 ]; do \
+			local patchFile="$1"; shift; \
+			local patchSha256="$1"; shift; \
+			ddist "$patchFile" "httpd/patches/apply_to_$HTTPD_VERSION/$patchFile"; \
+			echo "$patchSha256 *$patchFile" | sha256sum -c -; \
+			patch -p0 < "$patchFile"; \
+			rm -f "$patchFile"; \
+		done; \
+	}; \
+	patches $HTTPD_PATCHES; \
+	\
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	./configure \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
-	&& make -j "$(nproc)" \
-	&& make install \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
 	\
-	&& cd .. \
-	&& rm -r src man manual \
+	cd ..; \
+	rm -r src man manual; \
 	\
-	&& sed -ri \
+	sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-		"$HTTPD_PREFIX/conf/httpd.conf" \
+		"$HTTPD_PREFIX/conf/httpd.conf"; \
 	\
-	&& apt-get purge -y --auto-remove $buildDeps
+	apt-get purge -y --auto-remove $buildDeps
 
 COPY httpd-foreground /usr/local/bin/
 

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -16,26 +16,29 @@ RUN mkdir -p "$HTTPD_PREFIX" \
 WORKDIR $HTTPD_PREFIX
 
 ENV HTTPD_VERSION 2.4.28
-ENV HTTPD_SHA1 0b37522b808dcee72e1d56d656b0def530b820a2
+ENV HTTPD_SHA256 c1197a3a62a4ab5c584ab89b249af38cf28b4adee9c0106b62999fd29f920666
 
+# https://httpd.apache.org/security/vulnerabilities_24.html
+ENV HTTPD_PATCHES=""
+
+ENV APACHE_DIST_URLS \
 # https://issues.apache.org/jira/browse/INFRA-8753?focusedCommentId=14735394#comment-14735394
-ENV HTTPD_BZ2_URL https://www.apache.org/dyn/closer.cgi?action=download&filename=httpd/httpd-$HTTPD_VERSION.tar.bz2
-# not all the mirrors actually carry the .asc files :'(
-ENV HTTPD_ASC_URL https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
-
-# if the version is outdated, we have to pull from the archive :/
-ENV HTTPD_BZ2_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2
-ENV HTTPD_ASC_FALLBACK_URL https://archive.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.bz2.asc
+	https://www.apache.org/dyn/closer.cgi?action=download&filename= \
+# if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
+	https://www-us.apache.org/dist/ \
+	https://www.apache.org/dist/ \
+	https://archive.apache.org/dist/
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
-RUN set -x \
-	&& runDeps=' \
+RUN set -eux; \
+	\
+	runDeps=' \
 		apr-dev \
 		apr-util-dev \
 		apr-util-ldap \
 		perl \
-	' \
-	&& apk add --no-cache --virtual .build-deps \
+	'; \
+	apk add --no-cache --virtual .build-deps \
 		$runDeps \
 		ca-certificates \
 		coreutils \
@@ -57,53 +60,74 @@ RUN set -x \
 		tar \
 		# mod_deflate
 		zlib-dev \
+	; \
 	\
-	&& { \
-		wget -O httpd.tar.bz2 "$HTTPD_BZ2_URL" \
-		|| wget -O httpd.tar.bz2 "$HTTPD_BZ2_FALLBACK_URL" \
-	; } \
-	&& echo "$HTTPD_SHA1 *httpd.tar.bz2" | sha1sum -c - \
+	ddist() { \
+		local f="$1"; shift; \
+		local distFile="$1"; shift; \
+		local success=; \
+		local distUrl=; \
+		for distUrl in $APACHE_DIST_URLS; do \
+			if wget -O "$f" "$distUrl$distFile"; then \
+				success=1; \
+				break; \
+			fi; \
+		done; \
+		[ -n "$success" ]; \
+	}; \
+	\
+	ddist 'httpd.tar.bz2' "httpd/httpd-$HTTPD_VERSION.tar.bz2"; \
+	echo "$HTTPD_SHA256 *httpd.tar.bz2" | sha256sum -c -; \
+	\
 # see https://httpd.apache.org/download.cgi#verify
-	&& { \
-		wget -O httpd.tar.bz2.asc "$HTTPD_ASC_URL" \
-		|| wget -O httpd.tar.bz2.asc "$HTTPD_ASC_FALLBACK_URL" \
-	; } \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8 \
-	&& gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2 \
-	&& rm -rf "$GNUPGHOME" httpd.tar.bz2.asc \
+	ddist 'httpd.tar.bz2.asc' "httpd/httpd-$HTTPD_VERSION.tar.bz2.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A93D62ECC3C8EA12DB220EC934EA76E6791485A8; \
+	gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2; \
+	rm -rf "$GNUPGHOME" httpd.tar.bz2.asc; \
 	\
-	&& mkdir -p src \
-	&& tar -xf httpd.tar.bz2 -C src --strip-components=1 \
-	&& rm httpd.tar.bz2 \
-	&& cd src \
+	mkdir -p src; \
+	tar -xf httpd.tar.bz2 -C src --strip-components=1; \
+	rm httpd.tar.bz2; \
+	cd src; \
 	\
-# Apply source patches
-# End source patch list
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
+	patches() { \
+		while [ "$#" -gt 0 ]; do \
+			local patchFile="$1"; shift; \
+			local patchSha256="$1"; shift; \
+			ddist "$patchFile" "httpd/patches/apply_to_$HTTPD_VERSION/$patchFile"; \
+			echo "$patchSha256 *$patchFile" | sha256sum -c -; \
+			patch -p0 < "$patchFile"; \
+			rm -f "$patchFile"; \
+		done; \
+	}; \
+	patches $HTTPD_PATCHES; \
+	\
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	./configure \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
-	&& make -j "$(nproc)" \
-	&& make install \
+	; \
+	make -j "$(nproc)"; \
+	make install; \
 	\
-	&& cd .. \
-	&& rm -r src man manual \
+	cd ..; \
+	rm -r src man manual; \
 	\
-	&& sed -ri \
+	sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
-		"$HTTPD_PREFIX/conf/httpd.conf" \
+		"$HTTPD_PREFIX/conf/httpd.conf"; \
 	\
-	&& runDeps="$runDeps $( \
+	runDeps="$runDeps $( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)" \
-	&& apk add --virtual .httpd-rundeps $runDeps \
-	&& apk del .build-deps
+	)"; \
+	apk add --virtual .httpd-rundeps $runDeps; \
+	apk del .build-deps
 
 COPY httpd-foreground /usr/local/bin/
 

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -78,6 +78,8 @@ RUN set -x \
 	&& rm httpd.tar.bz2 \
 	&& cd src \
 	\
+# Apply source patches
+# End source patch list
 	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
 		--build="$gnuArch" \

--- a/update.sh
+++ b/update.sh
@@ -9,40 +9,47 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-nghttp2VersionDebian="$(docker run -i --rm debian:stretch-slim bash -c 'apt-get update -qq && apt-cache show "$@"' -- "libnghttp2-dev" |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
-opensslVersionDebian="$(docker run -i --rm debian:jessie-backports bash -c 'apt-get update -qq && apt-cache show "$@"' -- "openssl" |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
+nghttp2VersionDebian="$(docker run -i --rm debian:stretch-slim bash -c 'apt-get update -qq && apt-cache show "$@"' -- 'libnghttp2-dev' |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
+opensslVersionDebian="$(docker run -i --rm debian:jessie-backports bash -c 'apt-get update -qq && apt-cache show "$@"' -- 'openssl' |tac|tac| awk -F ': ' '$1 == "Version" { print $2; exit }')"
 
 travisEnv=
 for version in "${versions[@]}"; do
-	fullVersion="$(curl -sSL --compressed "https://www-us.apache.org/dist/httpd/" | grep -E '<a href="httpd-'"$version"'[^"-]+.tar.bz2"' | sed -r 's!.*<a href="httpd-([^"-]+).tar.bz2".*!\1!' | sort -V | tail -1)"
-	sha1="$(curl -fsSL "https://www-us.apache.org/dist/httpd/httpd-$fullVersion.tar.bz2.sha1" | cut -d' ' -f1)"
-	patchUrl="https://www-us.apache.org/dist/httpd/patches/apply_to_$fullVersion"
-	patchInsert="$(mktemp)"
-	echo "# Apply source patches" > $patchInsert
-	if curl -fsIo /dev/null "$patchUrl/"; then
-	    patchFiles="$(curl -fssL "$patchUrl/?C=M;O=A" | grep -E 'Source code patch$' | sed -r 's!.*<a href=\"([^\"]+)\".*!\1!')"
-	    for patch in $patchFiles; do
-		psum="$(curl -fssL $patchUrl/$patch | sha256sum | cut -d ' ' -f1)"
-		echo "        && { \\" >> $patchInsert
-		echo "             wget -O ${patch} \"$patchUrl/$patch\" \\" >> $patchInsert
-		echo "               && echo \"${psum} ${patch}\" | sha256sum -c - \\" >> $patchInsert
-		echo "               && patch -p0 < ${patch} \\" >>$patchInsert
-		echo "               && rm ${patch} \\" >> $patchInsert
-		echo "        ; } \\" >> $patchInsert
-	    done
+	fullVersion="$(
+		wget -qO- "https://www-us.apache.org/dist/httpd/" \
+			| grep -E '<a href="httpd-'"$version"'[^"-]+.tar.bz2"' \
+			| sed -r 's!.*<a href="httpd-([^"-]+).tar.bz2".*!\1!' \
+			| sort -V \
+			| tail -1
+	)"
+	sha256="$(wget -qO- "https://www-us.apache.org/dist/httpd/httpd-$fullVersion.tar.bz2.sha256" | cut -d' ' -f1)"
+	echo "$version: $fullVersion"
+
+	patchesUrl="https://www-us.apache.org/dist/httpd/patches/apply_to_$fullVersion"
+	patches=()
+	if wget --quiet --spider -O /dev/null -o /dev/null "$patchesUrl/"; then
+		patchFiles="$(
+			wget -qO- "$patchesUrl/?C=M;O=A" \
+				| grep -oE 'href="[^"]+[.]patch"' \
+				| cut -d'"' -f2 \
+				|| true
+		)"
+		for patchFile in $patchFiles; do
+			patchSha256="$(wget -qO- "$patchesUrl/$patchFile" | sha256sum | cut -d' ' -f1)"
+			[ -n "$patchSha256" ]
+			patches+=( "$patchFile" "$patchSha256" )
+		done
 	fi
-	echo "# End source patch list" >> $patchInsert
-	(
-		set -x
-		sed -ri \
-			-e 's/^(ENV HTTPD_VERSION) .*/\1 '"$fullVersion"'/' \
-			-e 's/^(ENV HTTPD_SHA1) .*/\1 '"$sha1"'/' \
-			-e 's/^(ENV NGHTTP2_VERSION) .*/\1 '"$nghttp2VersionDebian"'/' \
-			-e 's/^(ENV OPENSSL_VERSION) .*/\1 '"$opensslVersionDebian"'/' \
-                        -e '/# Apply source patches/{:a;N;/# End source patch list/!ba;' -e 'r '"$patchInsert" -e 'd;};' \
-			"$version/Dockerfile" "$version"/*/Dockerfile
-	)
-	rm $patchInsert
+	if [ "${#patches[@]}" -gt 0 ]; then
+		echo " - ${patches[*]}"
+	fi
+
+	sed -ri \
+		-e 's/^(ENV HTTPD_VERSION) .*/\1 '"$fullVersion"'/' \
+		-e 's/^(ENV HTTPD_SHA256) .*/\1 '"$sha256"'/' \
+		-e 's/^(ENV NGHTTP2_VERSION) .*/\1 '"$nghttp2VersionDebian"'/' \
+		-e 's/^(ENV OPENSSL_VERSION) .*/\1 '"$opensslVersionDebian"'/' \
+		-e 's/^(ENV HTTPD_PATCHES=").*(")$/\1'"${patches[*]}"'\2/' \
+		"$version/Dockerfile" "$version"/*/Dockerfile
 
 	for variant in alpine; do
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"

--- a/update.sh
+++ b/update.sh
@@ -16,6 +16,22 @@ travisEnv=
 for version in "${versions[@]}"; do
 	fullVersion="$(curl -sSL --compressed "https://www-us.apache.org/dist/httpd/" | grep -E '<a href="httpd-'"$version"'[^"-]+.tar.bz2"' | sed -r 's!.*<a href="httpd-([^"-]+).tar.bz2".*!\1!' | sort -V | tail -1)"
 	sha1="$(curl -fsSL "https://www-us.apache.org/dist/httpd/httpd-$fullVersion.tar.bz2.sha1" | cut -d' ' -f1)"
+	patchUrl="https://www-us.apache.org/dist/httpd/patches/apply_to_$fullVersion"
+	patchInsert="$(mktemp)"
+	echo "# Apply source patches" > $patchInsert
+	if curl -fsIo /dev/null "$patchUrl/"; then
+	    patchFiles="$(curl -fssL "$patchUrl/?C=M;O=A" | grep -E 'Source code patch$' | sed -r 's!.*<a href=\"([^\"]+)\".*!\1!')"
+	    for patch in $patchFiles; do
+		psum="$(curl -fssL $patchUrl/$patch | sha256sum | cut -d ' ' -f1)"
+		echo "        && { \\" >> $patchInsert
+		echo "             wget -O ${patch} \"$patchUrl/$patch\" \\" >> $patchInsert
+		echo "               && echo \"${psum} ${patch}\" | sha256sum -c - \\" >> $patchInsert
+		echo "               && patch -p0 < ${patch} \\" >>$patchInsert
+		echo "               && rm ${patch} \\" >> $patchInsert
+		echo "        ; } \\" >> $patchInsert
+	    done
+	fi
+	echo "# End source patch list" >> $patchInsert
 	(
 		set -x
 		sed -ri \
@@ -23,8 +39,10 @@ for version in "${versions[@]}"; do
 			-e 's/^(ENV HTTPD_SHA1) .*/\1 '"$sha1"'/' \
 			-e 's/^(ENV NGHTTP2_VERSION) .*/\1 '"$nghttp2VersionDebian"'/' \
 			-e 's/^(ENV OPENSSL_VERSION) .*/\1 '"$opensslVersionDebian"'/' \
+                        -e '/# Apply source patches/{:a;N;/# End source patch list/!ba;' -e 'r '"$patchInsert" -e 'd;};' \
 			"$version/Dockerfile" "$version"/*/Dockerfile
 	)
+	rm $patchInsert
 
 	for variant in alpine; do
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"


### PR DESCRIPTION
Poll Apache official patch site/tree in update.sh for potential
patches to apply to the selected release.  Update Dockerfile
RUN stanzas to directly include logic for downloading, verifying
and applying these patches.

Verification limited to checksum generated during update.sh run
as no official mechanism/signing appears to be in place for the
patches themselves.

Closes #75