### PR TITLE
Add support for mounting a directory with additional config files

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -147,6 +147,9 @@ RUN set -eux; \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
 		"$HTTPD_PREFIX/conf/httpd.conf"; \
 	\
+	mkdir -p $HTTPD_PREFIX/conf/optional; \
+	echo 'IncludeOptional conf/optional/*.conf' >> "$HTTPD_PREFIX/conf/httpd.conf"; \
+	\
 	apt-get purge -y --auto-remove $buildDeps
 
 COPY httpd-foreground /usr/local/bin/

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -128,6 +128,9 @@ RUN set -eux; \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
 		"$HTTPD_PREFIX/conf/httpd.conf"; \
 	\
+	mkdir -p $HTTPD_PREFIX/conf/optional; \
+	echo 'IncludeOptional conf/optional/*.conf' >> "$HTTPD_PREFIX/conf/httpd.conf"; \
+	\
 	runDeps="$runDeps $( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \


### PR DESCRIPTION
Right now, a user has to overwrite the whole `httpd.conf` for customizations (e.g. for named vhosts). This requires the user to `docker cp` the `httpd.conf` out of a container and keeping it up to date with container updates, or to create his/her own Dockerfile extending the image. Both ways carry the risk of the image going stale as well as being extra effort.

This change adds support for mounting a directory containing `*.conf` files similar to the `conf.d` mechanism in Debian/Ubuntu (where the idea was actually taken from).

Example usage:

    docker run -d \
    -p 80:80 \
    -v /srv/httpd/htdocs:/usr/local/apache2/htdocs:ro \
    -v /srv/httpd/conf:/usr/local/apache2/conf/optional:ro \
    httpd:2.4