### PR TITLE
Add missing libs for debian

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -37,6 +37,8 @@ ENV APACHE_DIST_URLS \
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -eux; \
 	\
+	# libbrotli is only in backports: https://packages.debian.org/stretch-backports/libbrotli-dev
+	echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list; \
 	# mod_http2 mod_lua mod_proxy_html mod_xml2enc
 	# https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/control?id=adb6f181257af28ee67af15fc49d2699a0080d4c
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -48,6 +50,9 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
+		libbrotli-dev \
+		libcurl4-openssl-dev \
+		libjansson-dev \
 		liblua5.2-dev \
 		libnghttp2-dev \
 		libpcre3-dev \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -46,6 +46,9 @@ RUN set -eux; \
 		gcc \
 		gnupg \
 		libc-dev \
+		# mod_md
+		curl-dev \
+		jansson-dev \
 		# mod_proxy_html mod_xml2enc
 		libxml2-dev \
 		# mod_lua


### PR DESCRIPTION
- `libbrotli-dev` for `mod_brotli`
- `libjansson` and `libcurl` for `mod_md`
  - ~**TODO** add these to alpine?~

Broli fix is currently Debian only, since the brotli library is only in `edge` on Alpine. Libraries for `mod_md` added to Debian and Alpine.

```console
$ docker build 2.4/
....
checking whether to enable mod_brotli... checking dependencies
checking for Brotli library >= 0.6.0 via pkg-config... yes
  setting MOD_BROTLI_LDADD to "-lbrotlienc"
  adding "-export-symbols-regex" to MOD_BROTLI_LDADD
  adding "brotli_module" to MOD_BROTLI_LDADD
checking whether to enable mod_brotli... shared (reallyall)
...
Building shared: mod_buffer.la mod_data.la mod_ratelimit.la mod_reqtimeout.la mod_ext_filter.la mod_request.la mod_include.la mod_filter.la mod_reflector.la mod_substitute.la mod_sed.la mod_charset_lite.la mod_deflate.la mod_xml2enc.la mod_proxy_html.la mod_brotli.la
...
/usr/share/apr-1.0/build/libtool --silent --mode=install install mod_brotli.la /usr/local/apache2/modules/
...
libbrotli1 set to manually installed.
```

There is only a small size difference:
```console
<none>              <none>              b67d2064ac8e        6 minutes ago       140MB
httpd               2.4                 b7cc370ac278        9 days ago          132MB
```

Fixes #132

https://packages.debian.org/stretch-backports/libbrotli-dev
https://pkgs.alpinelinux.org/packages?name=*brotli*&branch=edge&arch=x86_64
https://pkgs.alpinelinux.org/packages?name=*brotli*&branch=v3.9&arch=x86_64
