### PR TITLE
add 'IncludeOptional' to allow custom configs to be mounted

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -130,6 +130,9 @@ RUN set -eux; \
 		"$HTTPD_PREFIX/conf/httpd.conf" \
 		"$HTTPD_PREFIX/conf/extra/httpd-ssl.conf" \
 	; \
+	echo "Adding IncludeOptional to allow mounting custom configs" ; \
+	mkdir -p $HTTPD_PREFIX/conf/conf.d; \
+	echo "\nIncludeOptional $HTTPD_PREFIX/conf/conf.d/*.conf" >> $HTTPD_PREFIX/conf/httpd.conf; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \


### PR DESCRIPTION
this stems from my question here:

https://github.com/docker-library/httpd/issues/143

i think upstream (i.e. outside of a container) this doesnt necessarily make sense. but in a container, it totally does 