### PR TITLE
Add hardening flags

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -111,15 +111,21 @@ RUN set -eux; \
 	patches $HTTPD_PATCHES; \
 	\
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
+	CPPFLAGS="$(dpkg-buildflags --get CPPFLAGS)"; \
+	LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
 	./configure \
 		--build="$gnuArch" \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
 		--enable-mpms-shared=all \
+# enable the same hardening flags as Debian
+# - https://salsa.debian.org/apache-team/apache2/blob/87db7de4e59683fb03e97900f078d06ef2292748/debian/rules#L19-21
+# - https://salsa.debian.org/apache-team/apache2/blob/87db7de4e59683fb03e97900f078d06ef2292748/debian/rules#L115
 		--enable-pie \
-		CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security" \
-		CPPFLAGS="-D_FORTIFY_SOURCE=2" \
-		LDFLAGS="-Wl,--as-needed -Wl,-z,relro -Wl,-z,now" \
+		CFLAGS="-pipe $CFLAGS" \
+		CPPFLAGS="$CPPFLAGS" \
+		LDFLAGS="-Wl,--as-needed $LDFLAGS" \
 	; \
 	make -j "$(nproc)"; \
 	make install; \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -116,6 +116,10 @@ RUN set -eux; \
 		--prefix="$HTTPD_PREFIX" \
 		--enable-mods-shared=reallyall \
 		--enable-mpms-shared=all \
+		--enable-pie \
+		CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security" \
+		CPPFLAGS="-D_FORTIFY_SOURCE=2" \
+		LDFLAGS="-Wl,--as-needed -Wl,-z,relro -Wl,-z,now" \
 	; \
 	make -j "$(nproc)"; \
 	make install; \


### PR DESCRIPTION
Use the same hardening flags as the Debian build to enable RELRO,
stack protector and hardening.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>