### PR TITLE
Enable mod_brotli support for Alpine repo

### DIFF
--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -55,6 +55,8 @@ RUN set -eux; \
 		tar \
 		# mod_deflate
 		zlib-dev \
+		# mod_brotli
+		brotli-dev \
 	; \
 	\
 	ddist() { \


### PR DESCRIPTION
Same as https://github.com/docker-library/httpd/pull/134 just adding `brotli-dev` to enable official module `mod_brotli`