### PR TITLE
Swap "WINCH" for "SIGWINCH" (which fixes containerd's ability to use this value)

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -158,7 +158,7 @@ RUN set -eux; \
 	httpd -v
 
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop
-STOPSIGNAL WINCH
+STOPSIGNAL SIGWINCH
 
 COPY httpd-foreground /usr/local/bin/
 

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -149,7 +149,7 @@ RUN set -eux; \
 	httpd -v
 
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop
-STOPSIGNAL WINCH
+STOPSIGNAL SIGWINCH
 
 COPY httpd-foreground /usr/local/bin/
 


### PR DESCRIPTION
See https://github.com/docker-library/php/issues/907