### PR TITLE
Add apr-util-dbm_db to fix mod_dav

### DIFF
--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 	\
 	runDeps=' \
 		apr-dev \
+		apr-util-dbm_db \
 		apr-util-dev \
 		apr-util-ldap \
 		perl \


### PR DESCRIPTION
These lib files are not even a separate package in debian ([packages.debian.org](https://packages.debian.org/buster/amd64/libaprutil1/filelist) vs [pkgs.alpinelinux.org](https://pkgs.alpinelinux.org/contents?branch=v3.11&name=apr-util-dbm_db&arch=x86_64&repo=main)). They were added as recommends in Fedora ([bugzilla.redhat.com](https://bugzilla.redhat.com/show_bug.cgi?id=1491151) and [src.fedoreproject.org](https://src.fedoraproject.org/rpms/apr-util/c/7def96255723f89df0831670d8bd9a6be5a979c3))

It will be a slight increase in size (~112MB vs ~109MB)

Fixes #153