### PR TITLE
Remove build dependencies from image

### DIFF
--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -25,14 +25,16 @@ ENV HTTPD_PATCHES=""
 RUN set -eux; \
 	\
 	runDeps=' \
-		apr-dev \
+		apr \
+		apr-util \
 		apr-util-dbm_db \
-		apr-util-dev \
 		apr-util-ldap \
 		perl \
 	'; \
 	apk add --no-cache --virtual .build-deps \
 		$runDeps \
+		apr-dev \
+		apr-util-dev \
 		ca-certificates \
 		coreutils \
 		dpkg-dev dpkg \


### PR DESCRIPTION
I've noticed the alpine-based image has become almost twice as large (314 MB) as the debian-based image (166 MB).

Upon further investigation, I've found out several build dependencies are being included as part of the alpine-based image. Somehow, this became worse after the base image was upgraded to Alpine 3.12.

The following command can be run inside the container to determine which apk packages are included and how much space each one of them is taking: ``` apk info | xargs -n1 -I{} apk info -s {} | xargs -n4 | awk '{print $4,$1}' | sort -rn ```.

The output reveals several build dependencies such as llvm10-libs-10.0.0-r2 (~60.5 MB) and clang-libs-10.0.0-r2 (~60.0 MB) haven't been removed from the docker image.

This commit attempts to clean up unnecessary build dependencies from the final image, reducing the final image size to roughly 56 MB.

Closes #160