### PR TITLE
Move ca-certificates to runtime dependency

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR $HTTPD_PREFIX
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+# https://github.com/docker-library/httpd/issues/214
+		ca-certificates \
 		libaprutil1-ldap \
 # https://github.com/docker-library/httpd/issues/209
 		libldap-common \
@@ -35,7 +37,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
-		ca-certificates \
 		dirmngr \
 		dpkg-dev \
 		gcc \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -21,6 +21,8 @@ RUN set -eux; \
 		apr \
 		apr-util \
 		apr-util-ldap \
+# https://github.com/docker-library/httpd/issues/214
+		ca-certificates \
 		perl \
 	;
 
@@ -36,7 +38,6 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		apr-dev \
 		apr-util-dev \
-		ca-certificates \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \


### PR DESCRIPTION
Fixes https://github.com/docker-library/httpd/issues/214