### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -37,7 +37,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		bzip2 \
-		dirmngr \
 		dpkg-dev \
 		gcc \
 		gnupg \
@@ -159,7 +158,7 @@ RUN set -eux; \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --verify httpd.tar.bz2.asc httpd.tar.bz2; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" httpd.tar.bz2.asc; \
 	\
 	mkdir -p src; \


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).