### PR TITLE
Support reproducible builds for Debian

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:bookworm-slim
 
+ADD --chmod=0755 --checksum=sha256:4e7e6536b206488b2414d1fa2272e8bbf17fbe7d11e5648eb51284c8fa96b0a9 \
+       https://raw.githubusercontent.com/reproducible-containers/repro-sources-list.sh/v0.1.1/repro-sources-list.sh \
+       /usr/local/bin/repro-sources-list.sh
+
+# SOURCE_DATE_EPOCH is consumed by repro-sources-list.sh and build scripts
+ARG SOURCE_DATE_EPOCH
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 #RUN groupadd -r www-data && useradd -r --create-home -g www-data www-data
 
@@ -11,7 +18,20 @@ WORKDIR $HTTPD_PREFIX
 
 # install httpd runtime dependencies
 # https://httpd.apache.org/docs/2.4/install.html#requirements
-RUN set -eux; \
+#
+# When the secret "enable-repro-sources-list" is supplied,
+# /etc/apt is reconfigured to use `snapshot[-cloudflare].debian.org/archive/debian/<SOURCE_DATE_EPOCH>` to
+# reproduce packages. Disabled by default due to the slowness.
+# This is treated as a "secret" to hide it from build history for the reproducibility of the OCI config blob,
+# but its content is not confidential and can be just /dev/null.
+RUN \
+	--mount=type=cache,target=/var/cache/apt \
+	--mount=type=secret,id=enable-repro-sources-list,target=/mnt/enable-repro-sources-list \
+	set -eux; \
+	if [ -e /mnt/enable-repro-sources-list ]; then \
+		cp -a /etc/apt /etc/apt.bak; \
+		repro-sources-list.sh; \
+	fi; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 # https://github.com/docker-library/httpd/issues/214
@@ -20,7 +40,13 @@ RUN set -eux; \
 # https://github.com/docker-library/httpd/issues/209
 		libldap-common \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+	if [ -e /mnt/enable-repro-sources-list ]; then \
+		rm -rf /etc/apt; \
+		mv /etc/apt.bak /etc/apt; \
+	fi; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 ENV HTTPD_VERSION 2.4.58
 ENV HTTPD_SHA256 fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c5
@@ -29,8 +55,15 @@ ENV HTTPD_SHA256 fa16d72a078210a54c47dd5bef2f8b9b8a01d94909a51453956b3ec6442ea4c
 ENV HTTPD_PATCHES=""
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
-RUN set -eux; \
+RUN \
+	--mount=type=cache,target=/var/cache/apt \
+	--mount=type=secret,id=enable-repro-sources-list,target=/mnt/enable-repro-sources-list \
+	set -eux; \
 	\
+	if [ -e /mnt/enable-repro-sources-list ]; then \
+		cp -a /etc/apt /etc/apt.bak; \
+		repro-sources-list.sh; \
+	fi; \
 	# mod_http2 mod_lua mod_proxy_html mod_xml2enc
 	# https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/control?id=adb6f181257af28ee67af15fc49d2699a0080d4c
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -56,6 +89,10 @@ RUN set -eux; \
 		zlib1g-dev \
 	; \
 	rm -r /var/lib/apt/lists/*; \
+	if [ -e /mnt/enable-repro-sources-list ]; then \
+		rm -rf /etc/apt; \
+		mv /etc/apt.bak /etc/apt; \
+	fi; \
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -71,7 +108,7 @@ RUN set -eux; \
 			https://www.apache.org/dist/ \
 			https://archive.apache.org/dist/ \
 		; do \
-			if wget -O "$f" "$distUrl$distFile" && [ -s "$f" ]; then \
+			if wget --no-hsts -O "$f" "$distUrl$distFile" && [ -s "$f" ]; then \
 				success=1; \
 				break; \
 			fi; \
@@ -228,7 +265,9 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	httpd -v
+	httpd -v; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop
 STOPSIGNAL SIGWINCH

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -55,6 +55,7 @@ cat <<-EOH
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
+Builder: buildkit
 EOH
 
 # prints "$2$1$3$1...$N"


### PR DESCRIPTION
See:
- docker-library/official-images#16044
- - -
- <https://github.com/reproducible-containers/repro-sources-list.sh>
  is added to allow reconfiguring `/etc/apt` to use
  `snapshot[-cloudflare].debian.org/archive/debian/<SOURCE_DATE_EPOCH>`.
  However, this is disabled by default due to the slowness of the
  snapshot server.
  Reproducers may opt-in to enable this by specifying
  `--secret id=enable-repro-sources-list,source=/dev/null`.
  This is treated as a "secret" to hide it from build history for the
  reproducibility of the OCI config blob, but its content is not confidential.

- `/var/log/*` is removed as they contain timestamps

- `/var/cache/ldconfig/aux-cache` is removed as they contain inode
  number, etc.

- `wget` is executed with `--no-hsts` to disable creating `/root/.wget-hsts`

- To reproduce file timestamps, reproducers have to specify `rewrite-timestamp=true`
  as an exporter option (`--output`). This needs the master branch of
  BuildKit (will be included in BuildKit v0.13).

- The base image is not pinned by the hash.
  Reproducers may use the `CONVERT` action of source policies.
  <https://github.com/moby/buildkit/blob/v0.13.0-beta1/docs/build-repro.md>